### PR TITLE
pageSize bug fix

### DIFF
--- a/NDHTMLtoPDF.m
+++ b/NDHTMLtoPDF.m
@@ -180,7 +180,7 @@
 {
     NSMutableData *pdfData = [NSMutableData data];
     
-    UIGraphicsBeginPDFContextToData( pdfData, self.pageSize, nil );
+    UIGraphicsBeginPDFContextToData( pdfData, self.paperRect, nil );
         
     [self prepareForDrawingPages: NSMakeRange(0, self.numberOfPages)];
     


### PR DESCRIPTION
Previously, the pageSize was being ignored and all PDFs were coming out
as 8.5" x 11".
