### PR TITLE
Avoid extra blank page (with A4, in some unexpected cases)

### DIFF
--- a/NDHTMLtoPDF.h
+++ b/NDHTMLtoPDF.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-#define kPaperSizeA4 CGSizeMake(595,842)
+#define kPaperSizeA4 CGSizeMake(595.2,841.8)
 #define kPaperSizeLetter CGSizeMake(612,792)
 
 @class NDHTMLtoPDF;

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can also use the alternative following code to generate PDF directly from HT
                                          margins:(UIEdgeInsets)pageMargins
 </code>
 
-A paper size is only defined by a rect (e.g. kPaperSizeA4 CGSizeMake(595,842)).
+A paper size is only defined by a rect (e.g. kPaperSizeA4 CGSizeMake(595.2,841.8)).
 
 Please, be sure to create a property (e.g. `PDFCreator`) as NDHTMLtoPDF works asynchronously using UIWebView.
 


### PR DESCRIPTION
The A4 paper size has been defined with more precision, in order to
avoid an extra blank page in cases such as this one :

self.PDFCreator = [NDHTMLtoPDF createPDFWithHTML:@"Hello"
pathForPDF:[@"~/Documents/demo.pdf" stringByExpandingTildeInPath]
delegate:self pageSize:kPaperSizeA4 margins:UIEdgeInsetsMake(36, 36,
36, 36)];
