### PR TITLE
UIKit crash fixes.

### DIFF
--- a/NDHTMLtoPDF.m
+++ b/NDHTMLtoPDF.m
@@ -212,9 +212,16 @@
     self.webview.delegate = nil;
     [self.webview removeFromSuperview];
     
-    [self.view removeFromSuperview];
+    if (self.view) {
+        [self.view removeFromSuperview];
+    }
     
     self.webview = nil;
+}
+
+- (void) dealloc
+{
+    [self terminateWebTask];
 }
 
 @end


### PR DESCRIPTION
We had numerous UIKit crashes using this library.

We found that adding the dealloc method and calling terminateWebTask
fixed most of these crashes, then there was another crash less frequent
when the view in terminateWebTask was already nil when
removeFromSuperview is called.